### PR TITLE
ci: bump actions/checkout to v5

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write  # for actions-cool/maintain-one-comment to modify or create PR comments
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Changed Files
         id: changed-files


### PR DESCRIPTION
maintenance update to actions/checkout@v5 to align with the current runner stack (Node 24); nothing else modified.
release notes - https://github.com/actions/checkout/releases/tag/v5.0.0